### PR TITLE
fix(header-mobile):hight overflow scroll

### DIFF
--- a/side-nav-with-submenus/src/components/header-mobile.tsx
+++ b/side-nav-with-submenus/src/components/header-mobile.tsx
@@ -56,7 +56,7 @@ const HeaderMobile = () => {
       />
       <motion.ul
         variants={variants}
-        className="absolute grid w-full gap-3 px-10 py-16"
+        className="absolute grid w-full gap-3 px-10 py-16 max-h-screen overflow-y-auto"
       >
         {SIDENAV_ITEMS.map((item, idx) => {
           const isLastItem = idx === SIDENAV_ITEMS.length - 1; // Check if it's the last item


### PR DESCRIPTION
# Problem
Mobile nav doesn't scroll down [on mobile horizontal, items exceed screen height and when scrolling the page behind nav scroll not the nav itself]

![image](https://github.com/hqasmei/youtube-tutorials/assets/31366811/4b640022-e825-4196-addd-1a0d048e9b4f)

# Solution
Set max height for ul to match screen and overflow